### PR TITLE
Amelioration de la documentation sur comment afficher les donnees dans HA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # prixCarburant-home-assistant
 Client python permettant d'interroger l'openData du gouvernement sur le prix du carburant.
 
-https://www.prix-carburants.gouv.fr/ 
+https://www.prix-carburants.gouv.fr/
 
 Le client permet de :
  - Trouver les stations les plus proches dans un cercle de X km configurable a partir de votre adresse defini dans home assistant
@@ -11,14 +11,14 @@ Le client permet de :
 
 Aide à l'installation depuis HACS :
 
-Dans HACS, cliquer sur ... puis depots personnalisés 
+Dans HACS, cliquer sur ... puis depots personnalisés
 
 Ajouter :
 
 - URL : https://github.com/ryann72/prixCarburant-home-assistant
 - Catégorie : Intégration
 
-
+## Configuration
 Exemple de configuration :
 
 ### Configuration pour récupérer les stations dans un rayon de 20 km
@@ -61,8 +61,9 @@ unit_of_measurement: €
 friendly_name: PrixCarburant_44300020
 icon: 'mdi:currency-eur'
 ```
+### Configuration d'affichage dans Home Assistant
 
-Exemple de carte markdown :
+#### via carte markdown statique
 
 Permet d'afficher le prix des différents carburants proposés par la station.
 
@@ -86,7 +87,75 @@ GPLc : {{ state_attr("sensor.prixcarburant_44300020", "GPLc") }} €
 {%- endif %}
 ```
 
-Source code du client si vous souhaitez contribuer : "https://github.com/ryann72/essence"
+#### via carte markdown dynamique
 
+Le but est d'avoir un groupe de station essence et de trié automatiquement la liste sur le prix.
+
+* Crée un groupe avec les stations essences désirer
+```
+group:
+  station_essence:
+  - sensor.prixcarburant_38220002
+  - sensor.prixcarburant_38320006
+  - sensor.prixcarburant_38800003
+  - sensor.prixcarburant_38700003
+```
+* Carte markdown dynamique
+```
+type: markdown
+content: >-
+  {% set update = states('sensor.date') %}
+
+  {% set midnight = now().replace(hour=0, minute=0, second=0,
+  microsecond=0).timestamp() %}
+
+  {% set sorted_station_essence = "group.carburant" | expand |
+  sort(attribute='attributes.Gasoil') %}
+    | Station | &nbsp;&nbsp;&nbsp;&nbsp;Gasoil&nbsp;&nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;&nbsp;Gpl&nbsp;&nbsp;&nbsp;&nbsp; | Update |
+    | :------- | :----: | :----: | ------: |
+  {% for station in sorted_station_essence %}| {{-
+  state_attr(station.entity_id, 'Station name') -}}
+    |{%- if state_attr(station.entity_id, "Gasoil") == "None" -%}-{%- else -%}{{- state_attr(station.entity_id, 'Gasoil') -}}{%- endif -%}
+    |{%- if state_attr(station.entity_id, "GPLc") == "None" -%}-{%- else -%}{{- state_attr(station.entity_id, 'GPLc') -}}{%- endif -%}
+  {%- set event = state_attr(station.entity_id,'Last Update Gasoil') |
+  as_timestamp -%}
+  {%- set delta = ((event - midnight) // 86400) | int -%}
+    |{{ -delta }} Jours|
+  {% endfor %}
+title: Prix des carburants
+```
+
+#### via carte multiple-entity-row
+
+```
+type: entities
+title: Prix carburants
+entities:
+  - entity: sensor.prixcarburant_12340001
+    type: custom:multiple-entity-row
+    name: Auchan
+    icon: mdi:gas-station
+    show_state: false
+    entities:
+      - attribute: E98
+        name: E98
+        unit: €
+      - attribute: E10
+        name: E10
+        unit: €
+      - attribute: GPLc
+        name: GPL
+        unit: €
+  - entity: sensor.prixcarburant_12340003
+    type: custom:multiple-entity-row
+    name: E.Leclerc
+    icon: mdi:gas-station
+    show_state: false
+    entities:
+```
+
+# Information
+
+Source code du client si vous souhaitez contribuer : "https://github.com/ryann72/essence"
 
 Il s'agit d'un fork de https://github.com/max5962/prixCarburant-home-assistant, mis à jour afin de recuperer le E85 et le GPLc


### PR DESCRIPTION
Voici un merge request, non pas pour améliorer le custom_compoments mais la documentation sur comment afficher les données dans Home Assistant.

Idéalement, j'aurais vu ces deux screenshot pour montrer un résultat d'affichage possible : 
- https://forum.hacf.fr/uploads/default/original/2X/6/68418b4f3fcc38b584ce3f56efe0121c251f5d6b.png
- https://forum.hacf.fr/uploads/default/original/2X/5/5bcb6d091aa764431ddb271c3087c7544013c599.png

Tu en pense quoi ? 